### PR TITLE
Switch to 'optimist' gem

### DIFF
--- a/bin/flippy
+++ b/bin/flippy
@@ -2,7 +2,7 @@
 # encoding: UTF-8
 
 require_relative '../lib/flippy'
-require "trollop"
+require "optimist"
 
 class String
   include Flippy
@@ -14,7 +14,7 @@ end
 
 class OptionParser
   def self.parse!
-    Trollop::options do
+    Optimist::options do
       version "flippy #{Flippy::VERSION} (c) 2013 kyoendo"
       banner ~<<-EOS
         Fippy makes a text upside down, like "twitter" to "ɹəʇʇᴉʍʇ".

--- a/flippy.gemspec
+++ b/flippy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.required_ruby_version = '>=1.9.3'
-  gem.add_dependency 'trollop'
+  gem.add_dependency 'optimist'
   gem.add_dependency 'ruby-termios'
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
'trollop' has been deprecated, and flippy shows deprecation warnings when you run it.